### PR TITLE
TODO作成時の即時UI反映 & Apolloキャッシュ管理の改善

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "test:e2e": "cypress run",
     "test:e2e:open": "cypress open",
     "test:e2e:auth": "cypress run --spec 'cypress/e2e/auth/**/*.cy.js'",
-    "test:e2e:todo": "cypress run --spec 'cypress/e2e/todo/**/*.cy.js'",
+    "test:e2e:todo": "cypress run --spec 'cypress/e2e/todo/**/*.cy.ts'",
     "test:all": "npm run test && npm run test:e2e",
     "test:e2e:cleanup": "cypress run && cd ../server && php artisan migrate:fresh --seed",
     "test:e2e:cleanup:docker": "cypress run && docker-compose exec app php artisan migrate:fresh --seed",


### PR DESCRIPTION
---
issue https://github.com/kaminuma/laravel-graphql-memo-app/issues/37
TODOリストの新しい日付順ソートで新規登録TODOが表示されないバグ

**概要**:
新規TODO作成時にリストへ即時反映されるようにし、`Apollo Client`のキャッシュ戦略を `refetchQueries` から `update` へ変更しました🚀

---

### ✅ 目的

* 新規TODOが登録後すぐにリストへ表示されるようにしてUX向上。
* `refetchQueries` の使用をやめ、`update` 関数でのキャッシュ直接操作に切り替え、高速化と効率化を実現。

---

### 🔧 主な変更点

1. **`TodoForm.tsx`**

   * `refetchQueries` を削除し、`update` 関数でキャッシュを直接操作。
   * `cache.readQuery / writeQuery` を使って、取得済みのTODOリストに新規TODOを先頭に追加。
   * `GetTodosQuery` 型を正しくインポートし、型安全性を担保。


---

### 📈 効果・背景

* これまでの `refetchQueries` はネットワークリクエストを伴うため、UI反映にラグが発生していた。
* 今回の対応により、TODO作成直後にキャッシュへ即時反映されるため、UXが大幅に改善。
* 🎯 ネットワーク負荷を減らしつつ、UIの応答速度をミリ秒単位で高速化。

---

### 🔄 今後の展望

* 他の箇所でも同様のキャッシュ最適化を適用することで、アプリ全体の体感速度を底上げ可能。

---

